### PR TITLE
Fix: dependency errors when installing older redis version

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,6 +3,6 @@
   hosts: all
   vars:
     redis_sentinel_enabled: false
-    redis_server_version: "latest"
+    redis_server_version: "6:7.0.12"
   roles:
     - role: claranet.redis

--- a/molecule/sentinel/converge.yml
+++ b/molecule/sentinel/converge.yml
@@ -3,6 +3,6 @@
   hosts: all
   vars:
     redis_sentinel_enabled: true
-    redis_server_version: "latest"
+    redis_server_version: 6:7.0.12
   roles:
     - role: claranet.redis

--- a/tasks/debian-family.yml
+++ b/tasks/debian-family.yml
@@ -30,9 +30,9 @@
   ansible.builtin.set_fact:
     _redis_packages_list: >-
       {%- if redis_sentinel_enabled -%}
-        redis{{ _redis_server_version_format }}, redis-sentinel{{ _redis_sentinel_version_format }}
+        redis-server{{ _redis_server_version_format }},  redis-tools{{ _redis_server_version_format }}, redis{{ _redis_server_version_format }}, redis-sentinel{{ _redis_sentinel_version_format }}
       {%- else -%}
-        redis{{ _redis_server_version_format }}
+        redis-server{{ _redis_server_version_format }},  redis-tools{{ _redis_server_version_format }}, redis{{ _redis_server_version_format }}
       {%- endif -%}
 
 - name: Install redis packages


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix dependency errors when installing older redis version

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For allow users to install older version of redis

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In CI Workflow

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.


Closes #4 
