### PR TITLE
Fix: use redis master ip for set custom ip when autodiscovery does'nt works

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,6 +46,14 @@
     mode: 0750
     state: directory
 
+- name: Verify redis master ip autodiscovering in case of cluster installation
+  ansible.builtin.assert:
+    that:
+      - _redis_master_ip
+    fail_msg: "Unable to autodiscover master ip. Please set redis_master_ip role variables"
+    success_msg: "Discovering master ip with success: {{ _redis_master_ip }}"
+  when: redis_group | length > 1
+
 - name: "Include tasks for configure redis server"
   ansible.builtin.include_tasks: server.yml
   when: redis_server_enabled

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -59,32 +59,32 @@
     _redis_sentinel_config_rewrite.found != 1
 
 - name: Sentinel | ensure redis-sentinel config is set
-  block:
-      - name: Sentinel | ensure redis-sentinel general config is set
-        ansible.builtin.lineinfile:
-          dest: /etc/redis/sentinel_{{ redis_sentinel_port }}.conf
-          line: "{{ item.key }} {{ item.value }}"
-          regexp: "^{{ item.key }}"
-        loop: "{{ _redis_sentinel_conf_final |dict2items }}"
-
-      - name: Sentinel | ensure redis-sentinel sentinel config is set
-        ansible.builtin.lineinfile:
-          dest: /etc/redis/sentinel_{{ redis_sentinel_port }}.conf
-          line: "sentinel {{ item.key }} {{ item.value }}"
-          regexp: "^sentinel {{ item.key }}"
-        loop: "{{ _redis_sentinel_sentinel_conf_final |dict2items }}"
-
-      - name: Sentinel | ensure redis-sentinel master config is set
-        ansible.builtin.lineinfile:
-          dest: /etc/redis/sentinel_{{ redis_sentinel_port }}.conf
-          line: "sentinel {{ item.key }} {{ redis_sentinel_master_name }} {{ item.value }}"
-          regexp: "^sentinel {{ item.key }} {{ redis_sentinel_master_name }}"
-        loop: "{{ _redis_sentinel_master_conf_final |dict2items }}"
   notify: Redis-sentinel restart
   when: >-
     _redis_sentinel_config_rewrite.found is defined
     and
     _redis_sentinel_config_rewrite.found == 1
+  block:
+    - name: Sentinel | ensure redis-sentinel general config is set
+      ansible.builtin.lineinfile:
+        dest: /etc/redis/sentinel_{{ redis_sentinel_port }}.conf
+        line: "{{ item.key }} {{ item.value }}"
+        regexp: "^{{ item.key }}"
+      loop: "{{ _redis_sentinel_conf_final | dict2items }}"
+
+    - name: Sentinel | ensure redis-sentinel sentinel config is set
+      ansible.builtin.lineinfile:
+        dest: /etc/redis/sentinel_{{ redis_sentinel_port }}.conf
+        line: "sentinel {{ item.key }} {{ item.value }}"
+        regexp: "^sentinel {{ item.key }}"
+      loop: "{{ _redis_sentinel_sentinel_conf_final | dict2items }}"
+
+    - name: Sentinel | ensure redis-sentinel master config is set
+      ansible.builtin.lineinfile:
+        dest: /etc/redis/sentinel_{{ redis_sentinel_port }}.conf
+        line: "sentinel {{ item.key }} {{ redis_sentinel_master_name }} {{ item.value }}"
+        regexp: "^sentinel {{ item.key }} {{ redis_sentinel_master_name }}"
+      loop: "{{ _redis_sentinel_master_conf_final | dict2items }}"
 
 - name: Sentinel | Activate redis-sentinel service
   ansible.builtin.systemd:

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -68,9 +68,9 @@
   loop: "{{ _redis_conf_final | dict2items }}"
   when: redis_server_password is not defined
 
-- name: get databases parameters
-  ansible.builtin.shell: >-
-    set -o pipefail && redis-cli -p {{ redis_server_port }} -h {{ _redis_conf_final.bind }} {% if redis_server_password is defined %} -a {{ redis_server_password }} {% endif %} config get databases | tail -1
+- name: get databases parameters  # noqa risky-shell-pipe
+  ansible.builtin.shell: |
+    redis-cli -p {{ redis_server_port }} -h {{ _redis_conf_final.bind }} {% if redis_server_password is defined %} -a {{ redis_server_password }} {% endif %} config get databases | tail -1
   register: immutable
   changed_when: false
 

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -70,7 +70,7 @@
 
 - name: get databases parameters
   ansible.builtin.shell: >-
-    redis-cli -p {{ redis_server_port }} -h {{ _redis_conf_final.bind }} {% if redis_server_password is defined %} -a {{ redis_server_password }} {% endif %} config get databases | tail -1
+    set -o pipefail && redis-cli -p {{ redis_server_port }} -h {{ _redis_conf_final.bind }} {% if redis_server_password is defined %} -a {{ redis_server_password }} {% endif %} config get databases | tail -1
   register: immutable
   changed_when: false
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,7 +7,7 @@ _redis_master_host: >-
   {%-   endif -%}
   {%- endfor -%}
 
-_redis_autodiscover_master_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] if _redis_master_host == '' else (hostvars[_redis_master_host]['ansible_all_ipv4_addresses'] | first) }}"
+_redis_autodiscover_master_ip: "{{ (hostvars[_redis_master_host]['ansible_all_ipv4_addresses'] | first) if _redis_master_host != '' else hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
 
 _redis_master_ip: "{{ redis_master_ip if redis_master_ip != '' else _redis_autodiscover_master_ip }}"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,9 +7,11 @@ _redis_master_host: >-
   {%-   endif -%}
   {%- endfor -%}
 
-_redis_master_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] if _redis_master_host == '' else (hostvars[_redis_master_host]['ansible_all_ipv4_addresses'] | first) }}"
+_redis_autodiscover_master_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] if _redis_master_host == '' else (hostvars[_redis_master_host]['ansible_all_ipv4_addresses'] | first) }}"
 
-_config_version: "{% if redis_server_version == 'latest' or redis_server_version is version('6:7.2', '>=' ) %}7.2{% elif redis_server_version is version('6:6.2', '<' ) %}6.0{% elif redis_server_version is version('6:7.0', '<' ) %}6.2{% elif redis_server_version is version('6:7.2', '<' ) %}7.0{% endif %}"
+_redis_master_ip: "{{ redis_master_ip if redis_master_ip != '' else _redis_autodiscover_master_ip }}"
+
+_config_version: "{% if redis_server_version == 'latest' or redis_server_version is version('6:7.2', '>=') %}7.2{% elif redis_server_version is version('6:6.2', '<') %}6.0{% elif redis_server_version is version('6:7.0', '<') %}6.2{% elif redis_server_version is version('6:7.2', '<') %}7.0{% endif %}"
 
 _redis_conf_final: "{{ redis_conf_default | combine(redis_conf) | dict2items | rejectattr('value', 'equalto', '') | list | items2dict }}"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,7 +7,7 @@ _redis_master_host: >-
   {%-   endif -%}
   {%- endfor -%}
 
-_redis_autodiscover_master_ip: "{{ (hostvars[_redis_master_host]['ansible_all_ipv4_addresses'] | first) if _redis_master_host != '' else hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
+_redis_autodiscover_master_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] if _redis_master_host == '' and hostvars[inventory_hostname]['ansible_default_ipv4']['address'] is defined else ((hostvars[_redis_master_host]['ansible_all_ipv4_addresses'] | first) if hostvars[_redis_master_host]['ansible_all_ipv4_addresses'] is defined) }}"
 
 _redis_master_ip: "{{ redis_master_ip if redis_master_ip != '' else _redis_autodiscover_master_ip }}"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Configure redis master ip

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix Redis Cluster installation errors


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By using molecule with master-slave scenario

## Screenshots (if appropriate):

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] fix: use redis_master_ip for avoid to auto discover master ip
- [x] fix: ansible lint errors

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
